### PR TITLE
Adjusts UI to fit 6 PMs

### DIFF
--- a/DeadMoney/common/buildings/09_misc_resource.txt
+++ b/DeadMoney/common/buildings/09_misc_resource.txt
@@ -1,0 +1,103 @@
+## WIP ONLY HERE FOR UI TESTING
+
+building_logging_camp = {
+	building_group = bg_logging
+	texture = "gfx/interface/icons/building_icons/logging_camp.dds"
+	city_type = wood
+	required_construction = construction_cost_low
+	terrain_manipulator = forestry
+	levels_per_mesh = 5
+
+	production_method_groups = {
+		pmg_base_building_logging_camp
+		pmg_hardwood
+		pmg_equipment
+		pmg_transportation_building_logging_camp
+		pmg_ownership_capital_building_logging_camp
+		pmg_ownership_land_building_rubber_plantation
+	}
+}
+
+building_rubber_plantation = {
+	building_group = bg_rubber
+	texture = "gfx/interface/icons/building_icons/rubber_lodge.dds"
+	required_construction = construction_cost_low
+	
+	terrain_manipulator = forestry
+
+	unlocking_technologies = {
+		rubber_mastication
+	}
+
+	city_type = wood
+	levels_per_mesh = 5
+	
+	production_method_groups = {
+		pmg_base_building_rubber_plantation
+		pmg_train_automation_building_rubber_plantation
+		pmg_ownership_land_building_rubber_plantation
+	}
+}
+
+building_fishing_wharf = {
+	building_group = bg_fishing
+	texture = "gfx/interface/icons/building_icons/fishing_wharf.dds"
+	city_type = port
+	required_construction = construction_cost_low
+
+	production_method_groups = {
+		pmg_base_building_fishing_wharf
+		pmg_refrigeration_building_fishing_wharf
+		pmg_ownership_capital_building_fishing_wharf
+	}
+	
+	possible = {
+		error_check = {
+			severity = fail
+			is_sea_adjacent = yes
+		}
+	}
+}
+
+building_whaling_station = {
+	building_group = bg_whaling
+	texture = "gfx/interface/icons/building_icons/whaling_station.dds"
+	city_type = port
+	required_construction = construction_cost_low
+	
+	unlocking_technologies = {
+		navigation
+	}
+
+	production_method_groups = {
+		pmg_base_building_whaling_station
+		pmg_refrigeration_building_whaling_station
+		pmg_ownership_capital_building_whaling_station
+	}
+	
+	possible = {
+		error_check = {
+			severity = fail
+			is_sea_adjacent = yes
+		}
+	}
+}
+
+
+building_oil_rig = {
+	building_group = bg_oil_extraction
+	texture = "gfx/interface/icons/building_icons/oil_rig.dds"
+	city_type = mine
+	levels_per_mesh = 5
+	required_construction = construction_cost_medium
+
+	unlocking_technologies = {
+		pumpjacks
+	}
+	
+	production_method_groups = {
+		pmg_base_building_oil_rig
+		pmg_transportation_building_oil_rig
+		pmg_ownership_capital_building_oil_rig
+	}
+}

--- a/DeadMoney/common/history/buildings/dm_testbldinghist.txt
+++ b/DeadMoney/common/history/buildings/dm_testbldinghist.txt
@@ -7,6 +7,11 @@ BUILDINGS={
 				reserves=1
 				activate_production_methods={ "pm_simple_ranch" "pm_open_air_stockyards" "pm_standard_fences" "pm_unrefrigerated" "pm_privately_owned" }
 			}
+			create_building={
+				building="building_logging_camp"
+				level=1
+				reserves=1
+			}
 		}
 	}
 }

--- a/DeadMoney/gui/building_details_panel.gui
+++ b/DeadMoney/gui/building_details_panel.gui
@@ -1,0 +1,1534 @@
+# COPY-PASTED FOR NOW
+@panel_width_minus_10 = 530			# used to be 450
+@panel_width = 540  				# used to be 460
+@panel_width_half = 270				# used to be 230
+@panel_width_plus_10 = 550  		# used to be 470
+@panel_width_plus_14 = 554			# used to be 474
+@panel_width_plus_14_half = 277		# used to be 237
+@panel_width_plus_20 = 560			# used to be 480
+@panel_width_plus_30 = 570			# used to be 490
+@panel_width_plus_70 = 610			# used to be 530
+
+types building_panels
+{
+	type building_details_panel = default_block_window_two_lines {
+		name = "building_details_panel"
+		datacontext = "[BuildingDetailsPanel.AccessBuilding]"
+
+		blockoverride "window_header_name"
+		{
+			text = "[Building.GetName]"
+		}
+
+		blockoverride "window_header_name_line_two"
+		{
+			text = "BUILDING_DETAILS_LINE_TWO"
+		}
+
+		blockoverride "goto_button" {
+			button_icon_goto = {
+				datacontext = "[Building.GetState]"
+				size = { 30 30 }
+				onclick = "[InformationPanelBar.OpenStatePanel(Building.AccessState)]"
+				tooltip = "GO_TO_BUTTON_STATE"
+			}
+		}
+
+		blockoverride "fixed_top"
+		{
+			tab_buttons = {
+				# Overview
+				blockoverride "first_button" {
+					text = "BUILDING_DETAILS_PANEL_INFORMATION_TAB"
+				}
+				blockoverride "first_button_tooltip" {
+					tooltip = "BUILDING_DETAILS_PANEL_INFORMATION_TAB"
+				}
+				blockoverride "first_button_click" {
+					onclick = "[InformationPanel.SelectTab('default')]"
+				}
+				blockoverride "first_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('default')]"
+				}
+				blockoverride "first_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('default') )]"
+				}
+				blockoverride "first_button_selected" {
+					text = "BUILDING_DETAILS_PANEL_INFORMATION_TAB_SELECTED"
+				}
+				blockoverride "first_button_name" {
+					name = "tutorial_highlight_information_tab"
+				}
+
+				# Workforce
+				blockoverride "second_button" {
+					text = "WORKFORCE"
+				}
+				blockoverride "second_button_tooltip" {
+					tooltip = "WORKFORCE"
+				}
+				blockoverride "second_button_click" {
+					onclick = "[InformationPanel.SelectTab('workforce')]"
+				}
+				blockoverride "second_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('workforce')]"
+				}
+				blockoverride "second_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('workforce') )]"
+				}
+				blockoverride "second_button_selected" {
+					text = "WORKFORCE"
+				}
+				blockoverride "second_button_name" {
+					name = "tutorial_highlight_workforce_tab"
+				}
+
+				# Modifiers
+				blockoverride "third_button" {
+					text = "BUILDING_DETAILS_PANEL_MODIFIERS_TAB"
+				}
+				blockoverride "third_button_tooltip" {
+					tooltip = "BUILDING_DETAILS_PANEL_MODIFIERS_TAB"
+				}
+				blockoverride "third_button_click" {
+					onclick = "[InformationPanel.SelectTab('modifiers')]"
+				}
+				blockoverride "third_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('modifiers')]"
+				}
+				blockoverride "third_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('modifiers') )]"
+				}
+				blockoverride "third_button_selected" {
+					text = "BUILDING_DETAILS_PANEL_MODIFIERS_TAB_SELECTED"
+				}
+			}
+		}
+
+		blockoverride "scrollarea_content"
+		{
+			container = {
+				parentanchor = hcenter
+
+				building_details_panel_overview_content = {
+					visible = "[InformationPanel.IsTabSelected('default')]"
+					using = default_content_fade
+				}
+
+				building_details_panel_workforce_content = {
+					visible = "[InformationPanel.IsTabSelected('workforce')]"
+					using = default_content_fade
+				}
+
+				modifier_list = {
+					visible = "[InformationPanel.IsTabSelected('modifiers')]"
+					using = default_content_fade
+				}
+			}
+		}
+
+		blockoverride "goto_visibility" {
+			visible = yes
+		}
+
+		blockoverride "goto_properties" {
+			onclick = "[Building.AccessState.ZoomToCapital]"
+			tooltip = "ZOOM_TO_BUILDING_STATE"
+		}
+	}
+
+	type building_details_panel_overview_content = flowcontainer {
+		direction = vertical
+		using = default_list_position
+		margin_top = 5
+		margin_bottom = 10
+
+		### TOP INFO
+		flowcontainer = {
+			minimumsize = { @panel_width -1 }
+			parentanchor = hcenter
+			spacing = 10
+			margin_top = 10
+			margin_bottom = 10
+
+			flowcontainer = {
+				direction = vertical
+				spacing = 5
+				### BUILDING
+				widget = {
+					size = { 180 205 }
+
+					tooltipwidget = {
+						FancyTooltip_Building = {}
+					}
+
+					button = {
+						onrightclick = "[RightClickMenuManager.ShowForBuilding(Building.AccessSelf)]"
+						parentanchor = hcenter
+						position = { 0 5 }
+						size = { 152 152 }
+
+						icon = {
+							alpha = "[TransparentIfFalse(Building.IsActive)]"
+							texture = "[Building.GetTexture]"
+							size = { 100% 100% }
+						}
+
+						icon = {
+							visible = "[And( GreaterThan_int32( Building.GetExpansionLevel, '(int32)0'), Not( Building.IsActive ))]"
+							size = { 100% 100% }
+							texture = "gfx/interface/icons/generic_icons/inactive_building.dds"
+						}
+					}
+
+					### BUILD PROGRESS
+					default_progressbar_horizontal = {
+						visible = "[Building.HasConstructionQueued]"
+						tooltip = "BUILDING_PROGRESS_TOOLTIP"
+						size = { 115 18 }
+						parentanchor = bottom|hcenter
+						position = { 0 -60 }
+
+						blockoverride "values" {
+							value = "[Building.GetConstructionProgressPercentage]"
+							min = 0
+							max = 1
+						}
+
+						state = {
+							name = _show
+							next = 2
+							alpha = 0
+							duration = 0
+							size = { 50 18 }
+						}
+						state = {
+							name = 2
+							alpha = 1
+							duration = 0.15
+							size = { 115 18 }
+						}
+						state = {
+							name = _hide
+							alpha = 0
+							duration = 0.3
+							size = { 50 18 }
+						}
+
+						textbox = {
+							name = text
+							text = "[Building.GetConstructionRemainingWeeksDesc]"
+							parentanchor = center
+							autoresize = yes
+							align = hcenter|nobaseline
+						}
+					}
+
+					### DOWNSIZE / EXPAND
+					flowcontainer = {
+						position = { 0 -1 }
+						parentanchor = bottom|hcenter
+						spacing = 10
+
+						### DOWNSIZE
+						button_icon_minus_action = {
+							name = "tutorial_highlight_downsize"
+							size = { 35 35 }
+							parentanchor = vcenter
+							tooltip = "[Building.GetDownsizeTooltip]"
+							visible = "[And( IsValid( Building.Downsize ), Not( ShouldAskConfirmation( Building.Downsize ) ) )]"
+							onclick = "[Execute( Building.Downsize )]"
+							enabled = "[IsValid( Building.Downsize )]"
+							using = tooltip_below
+						}
+
+						### DOWNSIZE WITH CONFIRMATION
+						button_icon_minus_action = {
+							size = { 35 35 }
+							parentanchor = vcenter
+							tooltip = "[Building.GetDownsizeTooltip]"
+							visible = "[And( IsValid( Building.Downsize ), ShouldAskConfirmation( Building.Downsize ) )]"
+							onclick = "[PopupManager.AskConfirmation( Building.Downsize )]"
+							enabled = "[IsValid( Building.Downsize )]"
+							using = tooltip_below
+						}
+
+						### CANCEL CONSTRUCTION
+						button_icon_minus_action = {
+							size = { 35 35 }
+							parentanchor = vcenter
+							tooltip = "[Building.GetCancelConstructionTooltip]"
+							visible = "[IsValid( Building.CancelConstruction )]"
+							onclick = "[Execute( Building.CancelConstruction )]"
+							using = tooltip_below
+						}
+
+						### LEVEL
+						container = {
+							parentanchor = vcenter
+							background = {
+								using = entry_bg
+								margin = { 10 -2 }
+							}
+
+							textbox = {
+								name = "tutorial_higlight_expansion_level"
+								text = "[Building.GetExpansionLevelDesc]"
+								align = hcenter|nobaseline
+								using = fontsize_large
+								size = { 88 35 }
+								elide = right
+							}
+						}
+
+						### EXPAND
+						button_icon_plus_action = {
+							name = "tutorial_highlight_expand"
+							size = { 35 35 }
+							parentanchor = vcenter
+							tooltip = "[Building.GetQueueConstructionTooltip]"
+							onclick = "[Execute( Building.QueueConstruction )]"
+							enabled = "[IsValid( Building.QueueConstruction )]"
+							visible = "[And(Building.GetOwner.IsLocalPlayer, Building.IsExpandable)]"
+						}
+					}
+				}
+
+				button = {
+					visible = "[And( IsPotential( Building.ToggleAutoExpand ), Building.GetOwner.IsLocalPlayer)]"
+					size = { 180 40 }
+					using = default_button
+					onclick = "[Execute( Building.ToggleAutoExpand )]"
+
+					icon = {
+						using = highlighted_square_selection
+						visible = "[Building.IsAutoExpanding]"
+						alwaystransparent = yes
+					}
+
+					textbox = {
+						text = "CANCEL_AUTO_EXPAND"
+						visible = "[Building.IsAutoExpanding]"
+						tooltip = [Building.GetAutoExpandTooltip]
+						size = { 100% 100% }
+						align = nobaseline|hcenter
+						parentanchor = center
+					}
+
+					textbox = {
+						text = "AUTO_EXPAND"
+						visible = "[Not(Building.IsAutoExpanding)]"
+						tooltip = [Building.GetAutoExpandTooltip]
+						size = { 100% 100% }
+						align = nobaseline|hcenter
+						parentanchor = center
+					}
+				}
+			}
+
+			### RIGHT INFO
+			flowcontainer = {
+				direction = vertical
+				margin_top = 7
+
+				flowcontainer = {
+					direction = vertical
+					enabled = "[Building.IsActive]"
+
+					flowcontainer = {
+						direction = vertical
+						visible = "[And(Not(Building.IsGovernmentFunded), Not(Building.IsSubsistenceBuilding))]"
+						maximumsize = { 340 -1 }
+						minimumsize = { 340 -1 }
+						margin = { 10 10 }
+						spacing = 12
+
+						background = {
+							using = entry_bg_simple
+						}
+
+						textbox = {
+							text = "[concept_productivity]"
+							align = left|nobaseline
+							autoresize = yes
+							maximumsize = { 290 -1 }
+							multiline = yes
+						}
+
+						flowcontainer = {
+							spacing = 10
+
+							textbox = {
+								name = "tutorial_highlight_productivity_value"
+								using = productivity_tooltip_with_graph
+								raw_text = "@money![Building.GetAverageAnnualEarningsPerEmployeeFormatted|+]"
+								align = hcenter|nobaseline
+								autoresize = yes
+								maximumsize = { 120 -1 }
+								minimumsize = { 120 -1 }
+								margin_top = 10
+								margin_bottom = 10
+								multiline = yes
+								using = fontsize_mega
+								parentanchor = vcenter
+
+								background = {
+									using = entry_bg_simple
+								}
+							}
+
+							flowcontainer = {
+								visible = "[Not(Building.GetBuildingType.IsUnique)]"
+								name = "tutorial_highlight_productivity_gear_icons"
+								parentanchor = vcenter
+
+								direction = vertical
+								textbox = {
+									using = building_profitability_tooltip_with_graph
+									text = "BUILDING_RANK"
+									align = left|nobaseline
+									autoresize = yes
+									maximumsize = { 195 -1 }
+									elide = right
+								}
+
+								textbox = {
+									using = building_world_profitability_tooltip_with_graph
+									text = "BUILDING_RANK_WORLD"
+									align = left|nobaseline
+									autoresize = yes
+									maximumsize = { 195 -1 }
+									elide = right
+								}
+							}
+						}
+
+						textbox = {
+							text = "BUILDING_AVERAGE_WAGE"
+							tooltip = TOOLTIP_BUILDING_AVERAGE_WAGE
+							visible = "[Building.IsActive]"
+
+							align = left|nobaseline
+							autoresize = yes
+							elide = right
+						}
+					}
+
+					widget = {
+						size = { 330 25 }
+						visible = "[Building.IsMilitaryBuilding]"
+						hbox = {
+							spacing = 5
+							textbox = {
+								text = "BUILDING_STATUS"
+								align = left|nobaseline
+								autoresize = yes
+								elide = right
+							}
+							textbox = {
+								visible = "[Building.IsActive]"
+								text = "BUILDING_ACTIVE"
+								align = nobaseline
+								layoutpolicy_horizontal = expanding
+								size = { 0 25 }
+							}
+							textbox = {
+								visible = "[Not(Building.IsActive)]"
+								text = "BUILDING_INACTIVE"
+								align = left|nobaseline
+								layoutpolicy_horizontal = expanding
+								size = { 0 25 }
+							}
+						}
+					}
+
+					widget = {
+						size = { 3 3 }
+					}
+
+					widget = {
+						size = { 330 40 }
+						parentanchor = hcenter
+						default_progressbar_horizontal = {
+							tooltip = "TOOLTIP_BUILDING_EMPLOYMENT"
+							size = { 100% 34 }
+							parentanchor = vcenter
+
+							blockoverride "values" {
+								value = "[FixedPointToFloat(Building.GetEmploymentPercentage)]"
+								min = 0
+								max = 1
+							}
+						}
+
+						flowcontainer = {
+							parentanchor = vcenter
+							textbox = {
+								text = EMPLOYMENT_BAR
+								margin_left = 10
+								margin_bottom = 5
+								margin_top = 5
+								align = hcenter|nobaseline
+								autoresize = yes
+								parentanchor = vcenter
+								widgetanchor = vcenter
+							}
+
+							textbox = {
+								visible = "[LessThan_int32(Building.GetNoOfEmployed, Building.GetEmployeeCap)]"
+								raw_text = "/ #maximum [Building.GetEmployeeCap|1*]#!"
+								margin_left = 7
+								align = hcenter|nobaseline
+								autoresize = yes
+								parentanchor = vcenter
+								widgetanchor = vcenter
+							}
+						}
+
+						icon = {
+							visible = "[And(Not(Building.IsSubsistenceBuilding), Building.HasFailedHires)]"
+							size = { 30 30 }
+							texture = "gfx/interface/icons/generic_icons/employment_not_full.dds"
+							parentanchor = right|vcenter
+							tooltip = "NOT_FULLY_EMPLOYED"
+							position = { -7 0 }
+						}
+
+						icon = {
+							visible = "[And(And(And(Not(Building.IsGovernmentFunded), Not(GreaterThan_CFixedPoint(Building.GetAverageAnnualEarningsPerEmployee, '(CFixedPoint)0'))) , Not(Building.IsSubsidized)), EqualTo_CFixedPoint(Building.GetCurrentCashReserves, '(CFixedPoint)0'))]"
+							size = { 30 30 }
+							texture = "gfx/interface/icons/generic_icons/employment_not_full.dds"
+							parentanchor = right|vcenter
+							tooltip = "NOT_HIRING"
+							position = { -7 0 }
+						}
+
+						icon = {
+							visible = "[And(And(And(And(Not(Building.IsSubsistenceBuilding), Not(Building.HasFailedHires)), Building.IsActive), LessThan_int32(Building.GetNoOfEmployed, Building.GetEmployeeCap)), GreaterThan_CFixedPoint(Building.GetAverageAnnualEarningsPerEmployee, '(CFixedPoint)0'))]"
+							size = { 30 30 }
+							parentanchor = right|vcenter
+							texture = "gfx/interface/icons/generic_icons/employment_not_full_hiring.dds"
+							tooltip = "TOOLTIP_BUILDING_HIRING"
+							position = { -7 0 }
+						}
+					}
+
+					widget = {
+						size = { 3 8 }
+					}
+
+					widget = {
+						alpha = "[TransparentIfFalse(Building.IsActive)]"
+						visible = "[And(GreaterThan_CFixedPoint(Building.GetMaxCashReserves, '(CFixedPoint)0'), Building.IsActive)]"
+						size = { 330 34 }
+						parentanchor = hcenter
+						using = cash_reserves_tooltip_with_graph
+
+						gold_progressbar_horizontal = {
+							size = { 100% 100% }
+							alpha = "[TransparentIfFalse(Building.IsActive)]"
+							visible = "[And(GreaterThan_CFixedPoint(Building.GetMaxCashReserves, '(CFixedPoint)0'), Building.IsActive)]"
+
+							blockoverride "glow_size" {
+								size = { 40 100% }
+							}
+
+							parentanchor = vcenter
+							blockoverride "values" {
+								min = 0
+								max = "[FixedPointToFloat(Building.GetMaxCashReserves)]"
+								value = "[FixedPointToFloat(Building.GetCurrentCashReserves)]"
+							}
+
+							progressbar_highlight = {
+								visible = "[GreaterThanOrEqualTo_CFixedPoint(Building.GetCurrentCashReserves, Building.GetMaxCashReserves)]"
+							}
+						}
+
+						changed_value_decreased_progressbar_horizontal = {
+							size = { 100% 100% }
+							visible = "[GreaterThan_CFixedPoint(GetPrevTrendValue(Building.GetCashReservesTrend), GetTrendValue(Building.GetCashReservesTrend))]"
+
+							blockoverride "second_progressbar" {}
+
+							blockoverride "values" {
+								min = 0
+								max = "[FixedPointToFloat(Building.GetMaxCashReserves)]"
+								value = "[FixedPointToFloat(Building.GetCurrentCashReserves)]"
+							}
+							blockoverride "glow_size" {
+								size = { 40 100% }
+							}
+							blockoverride "arrow_texture_density" {
+								texture_density = 4 #use to match height of progressbar
+							}
+						}
+
+						changed_value_increased_progressbar_horizontal = {
+							size = { 100% 100% }
+							visible = "[GreaterThan_CFixedPoint(GetTrendValue(Building.GetCashReservesTrend), GetPrevTrendValue(Building.GetCashReservesTrend))]"
+
+							blockoverride "second_progressbar" {}
+
+							blockoverride "values" {
+								min = 0
+								max = "[FixedPointToFloat(Building.GetMaxCashReserves)]"
+								value = "[FixedPointToFloat(Building.GetCurrentCashReserves)]"
+							}
+							blockoverride "glow_size" {
+								size = { 40 100% }
+							}
+							blockoverride "arrow_texture_density" {
+								texture_density = 4 #use to match height of progressbar
+							}
+						}
+
+						flowcontainer = {
+							parentanchor = vcenter
+							textbox = {
+								text = BUILDING_CASH_RESERVES
+								margin_left = 10
+								align = hcenter|nobaseline
+								autoresize = yes
+								parentanchor = vcenter
+							}
+
+							textbox = {
+								raw_text = " / #maximum [Building.GetMaxCashReserves|k]#!"
+								visible = "[LessThan_CFixedPoint(Building.GetCurrentCashReserves, Building.GetMaxCashReserves)]"
+								align = hcenter|nobaseline
+								autoresize = yes
+								parentanchor = vcenter
+							}
+						}
+					}
+
+					widget = {
+						visible = "[Not(EqualTo_CFixedPoint(Building.GetGovernmentExpenses, '(CFixedPoint)0'))]"
+						size = { 10 10 }
+					}
+
+					### TIMED MODIFIERS
+					flowcontainer = {
+						parentanchor = left
+
+						datamodel = "[Building.GetTimedModifiers]"
+						spacing = 5
+
+						using = clickthrough_blocker
+
+						item = {
+							icon = {
+								tooltip = "[TimedModifier.GetTooltip]"
+								texture = "[TimedModifier.GetIcon]"
+								size = { 30 30 }
+							}
+						}
+					}
+
+					widget = {
+						size = { 11 11 }
+						visible = "[And(Not(Building.IsGovernmentFunded), Not(Building.IsSubsistenceBuilding))]"
+					}
+
+					### battalions mobilized
+					widget = {
+						visible = "[Building.GetHQ.IsLandHQ]"
+
+						size = { 330 25 }
+						tooltip = "BUILDING_MOBILIZED_BATTALIONS_TOOLTIP"
+						hbox = {
+							textbox = {
+								text = "BUILDING_BATTALIONS_MOBILIZED"
+								align = left|nobaseline
+								layoutpolicy_horizontal = expanding
+								size = { 0 25 }
+								elide = right
+							}
+							textbox = {
+								raw_text = "@battalions! #v [Building.GetNumberOfFullyMobilizedBattalions]#! / [Building.GetNumberOfCombatUnits] (#v [Building.GetMobilizationRatio|%]#!)"
+								align = nobaseline
+								autoresize = yes
+							}
+					 	}
+					}
+
+					widget = {
+						size = { 10 10 }
+						visible = "[Building.IsBuildingType('building_trade_center')]"
+					}
+
+					### MARKET
+					flowcontainer = {
+						margin_top = 10
+						parentanchor = hcenter
+						visible = "[Building.IsBuildingType('building_trade_center')]"
+
+						button = {
+							using = default_button
+							onclick = "[InformationPanelBar.OpenMarketPanel(Building.AccessState.AccessMarket)]"
+
+							textbox = {
+								resizeparent = yes
+								text = "[Building.GetState.GetMarket.GetName]"
+								align = center|nobaseline
+								autoresize = yes
+								maximumsize = { 250 -1 }
+								minimumsize = { 250 -1 }
+								margin = { 10 10 }
+								multiline = yes
+								parentanchor = center
+							}
+						}
+					}
+				}
+			}
+		}
+
+		### SUBSISTENCE INFO
+		textbox = {
+			using = default_list_position
+			text = "SUBSISTENCE_CONCEPT_CLEAN"
+			visible = "[Building.IsSubsistenceBuilding]"
+			autoresize = yes
+			multiline = yes
+			maximumsize = { @panel_width -1 }
+			margin_top = 10
+			margin_bottom = 20
+		}
+
+		### URBAN INFO
+		textbox = {
+			using = default_list_position
+			text = "URBAN_CENTER_EXPLANATION"
+			visible = "[Building.IsUrbanCenter]"
+			autoresize = yes
+			multiline = yes
+			maximumsize = { @panel_width -1 }
+			margin_top = 10
+			margin_bottom = 20
+		}
+
+
+		### PRODUCTION METHODS
+		flowcontainer = {
+			visible = "[Not(Building.IsMilitaryBuilding)]"
+			using = default_list_position
+			direction = vertical
+			minimumsize = { @panel_width -1 }
+			margin = { 0 10 }
+			spacing = 10
+
+			default_header_2texts = {
+				blockoverride "text1" {
+					text = "PRODUCTION_METHODS"
+				}
+			}
+
+			container = {
+				parentanchor = hcenter
+				minimumsize = { @panel_width -1 }
+				container = {
+					name = "tutorial_highlight_production_methods"
+
+					flowcontainer = {
+						datamodel = "[Building.AccessProductionMethodGroups]"
+						spacing = 4
+
+						item = {
+							widget = {
+								size = { 74 75 }
+								datacontext = "[Building.AccessProductionMethod(ProductionMethodGroup.Self)]"
+								datacontext = "[ProductionMethod]"
+								datacontext = "[Building]"
+								datacontext = "[ProductionMethodGroup]"
+								using = tooltip_above
+
+								tooltip = "CHANGE_FROM_CURRENT_PRODUCTION_METHOD_TOOLTIP"
+
+								button = {
+									visible = "[NotEqualTo_int32( GetDataModelSize( ProductionMethodGroup.AccessBuildingProductionMethods( Building.Self ) ), '(int32)1' )]"
+									using = expand_button_bg_no_fade
+									size = { 74 75 }
+									enabled = "[Building.IsOwner( GetPlayer.Self )]"
+									onclick = "[RightClickMenuManager.ToggleSwitchProductionMethodMenu(Building.AccessSelf, ProductionMethodGroup.AccessSelf, PdxGuiWidget.AccessSelf)]"
+								}
+
+								icon = {
+									size = { 60 60 }
+									parentanchor = center
+									texture = "[ProductionMethod.GetTexture]"
+								}
+
+								### new pm
+								has_new_pm_icon	= {
+									blockoverride "visible" {
+										visible = "[And(Building.IsOwner( GetPlayer.Self ), GetPlayer.HasNewProductionMethodInSameGroup( Building.GetBuildingType.Self, ProductionMethod.Self ))]"
+									}
+									position = { 0 0 }
+									tooltip = "TOOLTIP_NEW_PRODUCTION_METHOD"
+									parentanchor = bottom
+								}
+
+								textbox = {
+									raw_text = "#P #bold [ProductionMethodGroup.GetNumAvailableOptions(Building.AccessSelf)]#!#!"
+									parentanchor = top|right
+									position = { -7 2 }
+									autoresize = yes
+									align = right|nobaseline
+									visible = "[NotEqualTo_int32( ProductionMethodGroup.GetNumAvailableOptions(Building.AccessSelf), '(int32)1')]"
+									tooltip = "PRODUCTION_METHOD_OPTIONS"
+									using = tooltip_above
+									using = fontsize_small
+
+									background = {
+										using = default_background
+										margin = { 8 4 }
+									}
+								}
+							}
+						}
+					}
+				}
+
+				### subsidize
+				button = {
+					name = "tutorial_highlight_subsidize"
+					using = default_button
+					parentanchor = top|right
+					visible = "[And(Building.GetBuildingType.CanBeSubsidized, Building.IsSubsidized)]"
+					tooltip = SUBSIDIZED_YES
+					enabled = "[IsValid( Building.ToggleSubsidies )]"
+					onclick = "[Execute( Building.ToggleSubsidies )]"
+					size = { 75 75 }
+					margin_bottom = 15
+
+					button = {
+						texture = "gfx/interface/production_methods/subsidized.dds"
+						size = { 32 32 }
+						position = { 0 -2 }
+						alwaystransparent = yes
+						parentanchor = center
+					}
+
+					textbox = {
+						raw_text = "#N #bold -[Building.GetSubsidies|D]#!"
+						autoresize = yes
+						parentanchor = hcenter|bottom
+						margin_bottom = 8
+					}
+
+					icon = {
+						using = highlighted_square_selection
+						visible = "[And(Building.GetBuildingType.CanBeSubsidized, Building.IsSubsidized)]"
+						alwaystransparent = yes
+					}
+				}
+
+
+				button = {
+					name = "tutorial_highlight_subsidize_button_building_details"
+					parentanchor = top|right
+					visible = "[And(Building.GetBuildingType.CanBeSubsidized, Not(Building.IsSubsidized))]"
+					tooltip = SUBSIDIZED_NO
+					enabled = "[IsValid( Building.ToggleSubsidies )]"
+					onclick = "[Execute( Building.ToggleSubsidies )]"
+					using = default_button
+					size = { 70 75 }
+
+					button = {
+						texture = "gfx/interface/production_methods/subsidized_not.dds"
+						size = { 32 32 }
+						position = { 0 -2 }
+						alwaystransparent = yes
+						parentanchor = center
+					}
+				}
+			}
+		}
+
+		### PRODUCTION METHODS MILITARY BUILDINGS (BATTALIONS)
+		flowcontainer = {
+			visible = "[Building.IsMilitaryBuilding]"
+			using = default_list_position
+			direction = vertical
+			minimumsize = { @panel_width -1 }
+			margin = { 0 10 }
+			spacing = 10
+
+			default_header_2texts = {
+				blockoverride "text1" {
+					text = "COMBAT_UNITS_BUILDING_HEADER"
+				}
+			}
+
+			flowcontainer = {
+				margin = { 5 0 }
+				spacing = 5
+
+				# Troop image on the left
+				widget = {
+					size = { 175 131 }
+					visible = "[GreaterThan_int32(Building.GetNumberOfCombatUnits, '(int32)0')]"
+
+					background = {
+						texture = "[Building.GetCombatUnitTexture]"
+						modify_texture = {
+							using = simple_frame_mask
+						}
+					}
+					icon = {
+						using = simple_frame
+						size = { 100% 100% }
+					}
+				}
+
+				# Building info on the right
+				widget = {
+					size = { 330 150 }
+
+					textbox = {
+						position = { 2 15 }
+						text = "PRODUCTION_METHODS"
+						autoresize = yes
+						maximumsize = { 200 -1 }
+						align = left|nobaseline
+					}
+
+
+					### Production methods (copy from buildings panel)
+					flowcontainer = {
+						datamodel = "[Building.AccessProductionMethodGroups]"
+						spacing =  5
+						parentanchor = vcenter
+
+						item = {
+							widget = {
+								size = { 62 62 }
+								datacontext = "[Building.AccessProductionMethod(ProductionMethodGroup.Self)]"
+								datacontext = "[ProductionMethod]"
+								datacontext = "[Building]"
+								datacontext = "[ProductionMethodGroup]"
+								using = tooltip_above
+								tooltip = "CHANGE_FROM_CURRENT_PRODUCTION_METHOD_TOOLTIP"
+
+								button = {
+									visible = "[NotEqualTo_int32( GetDataModelSize( ProductionMethodGroup.AccessBuildingProductionMethods( Building.Self ) ), '(int32)1' )]"
+									using = expand_button_bg_no_fade
+									enabled = "[Building.IsOwner( GetPlayer.Self )]"
+									size = { 100% 100% }
+									onclick = "[RightClickMenuManager.ToggleSwitchProductionMethodMenu(Building.AccessSelf, ProductionMethodGroup.AccessSelf, PdxGuiWidget.AccessSelf)]"
+								}
+
+								icon = {
+									size = { 47 47 }
+									parentanchor = center
+									texture = "[ProductionMethod.GetTexture]"
+								}
+
+								### new pm
+								has_new_pm_icon = {
+									position = { -2 2 }
+									parentanchor = bottom|left
+									blockoverride "visible" {
+										visible = "[And(Building.IsOwner( GetPlayer.Self ), GetPlayer.HasNewProductionMethodInSameGroup( Building.GetBuildingType.Self, ProductionMethod.Self ))]"
+									}
+								}
+
+								### nr available
+								textbox = {
+									raw_text = "#P #bold [ProductionMethodGroup.GetNumAvailableOptions(Building.AccessSelf)]#!#!"
+									parentanchor = top|right
+									position = { -5 0 }
+									autoresize = yes
+									align = right|nobaseline
+									visible = "[NotEqualTo_int32( ProductionMethodGroup.GetNumAvailableOptions(Building.AccessSelf), '(int32)1')]"
+									tooltip = "PRODUCTION_METHOD_OPTIONS"
+									using = tooltip_above
+									using = fontsize_small
+
+									background = {
+										using = default_background
+										margin = { 8 4 }
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			### Building commanders list
+			flowcontainer = {
+				parentanchor = hcenter
+				direction = vertical
+				spacing = 10
+				datamodel = "[Building.GetCombatUnitCommanders]"
+
+				item = {
+					commander_entry_building = {}
+				}
+
+			}
+
+			### Reserve units list
+			buildings_reserves_hq_item = { }
+
+		}
+
+		flowcontainer = {
+			visible = "[Building.HasTradeRouteRevenue]"
+			using = default_list_position
+			direction = vertical
+			minimumsize = { @panel_width -1 }
+
+			default_header_2texts = {
+				blockoverride "text1" {
+					text = "TRADE_ROUTES"
+				}
+			}
+
+			dynamicgridbox = {
+				datamodel = "[Building.AccessPlayerTradeRoutes]"
+				parentanchor = hcenter
+				
+				item = {
+					trade_route_list_item = {
+						datacontext = "[Building.GetState.GetOwner]"
+						datacontext = "[Building.GetState.GetMarket]"
+					}
+				}
+			}
+			dynamicgridbox = {
+				datamodel = "[Building.AccessNonPlayerTradeRoutes]"
+				parentanchor = hcenter
+				
+				item = {
+					trade_route_list_item = {
+						datacontext = "[Building.GetState.GetOwner]"
+						datacontext = "[Building.GetState.GetMarket]"						
+					}
+				}
+			}
+		}
+
+		### PROCESS
+		flowcontainer = {
+			using = default_list_position
+			direction = vertical
+			minimumsize = { @panel_width -1 }
+
+			default_header_2texts = {
+				blockoverride "text1" {
+					text = "PROCESS"
+				}
+				blockoverride "right" {
+					flowcontainer = {
+						parentanchor = right|vcenter
+						margin_right = 10
+						spacing = 10
+
+						textbox = {
+							text = "PROCESS_BALANCE"
+							autoresize = yes
+							multiline = yes
+							maximumsize = { 200 -1 }
+							parentanchor = vcenter
+							align = left|nobaseline
+						}
+
+						textbox = {
+							name = "tutorial_highlight_weekly_balance_building"
+							raw_text = "@money!#v [Building.GetBalance|D+=]#!"
+							tooltip = "[Building.GetBalanceDesc]"
+							autoresize = yes
+							multiline = yes
+							maximumsize = { 200 -1 }
+							parentanchor = vcenter
+							align = left|nobaseline
+							using = fontsize_large
+						}
+					}
+				}
+			}
+
+			widget = { size = { 10 10 }}
+
+			### list
+			container = {
+				minimumsize = { @panel_width -1 }
+				parentanchor = hcenter
+
+				### left
+				textbox = {
+					parentanchor = vcenter
+					margin_left = 20
+					align =  nobaseline
+					using = empty_state_text_properties
+					visible = "[Not(Building.IsActive)]"
+					text = "BUILDING_INACTIVE_CONSUMPTION_EMPTY_STATE"
+					multiline = yes
+					max_width = 250
+					min_width = 250
+					autoresize = yes
+				}
+
+				flowcontainer = {
+					name = "tutorial_highlight_expenses"
+					direction = vertical
+					spacing = 5
+					parentanchor = left|vcenter
+					minimumsize = { 250 -1 }
+					ignoreinvisible = yes
+					visible = "[Building.IsActive]"
+
+					### goods
+					flowcontainer = {
+						parentanchor = hcenter
+						direction = vertical
+						datamodel = "[Building.AccessConsumedGoods]"
+
+						item = {
+							widget = {
+								size = { 250 50 }
+								name = "tutorial_highlight_goods"
+								tooltipwidget = {
+									FancyTooltip_Goods = {}
+								}
+
+								button = {
+									size = { 100% 40 }
+									parentanchor = vcenter
+									using = default_button
+									onclick = "[InformationPanelBar.OpenGoodsStatePanel(Building.GetState, Goods.Self)]"
+									onrightclick = "[RightClickMenuManager.ShowForGoods(Goods.AccessSelf)]"
+								}
+
+
+								icon = {
+									size = { 50 50 }
+									texture = "[Goods.GetTexture]"
+									position = { 3 0 }
+									parentanchor = left|vcenter
+								}
+
+								icon = {
+									size = { 25 25 }
+									visible = "[And(Not(Building.HasMaximumInputShortage(Goods.Self)),Building.HasInputShortage(Goods.Self))]"
+									texture = "gfx/interface/icons/generic_icons/goods_shortage.dds"
+									tooltip = "GOODS_INPUT_SHORTAGE_TOOLTIP"
+									parentanchor = bottom
+								}
+
+								icon = {
+									size = { 25 25 }
+									visible = "[Building.HasMaximumInputShortage(Goods.Self)]"
+									texture = "gfx/interface/icons/generic_icons/goods_shortage.dds"
+									tooltip = "GOODS_INPUT_SHORTAGE_MAX_TOOLTIP"
+									parentanchor = bottom
+								}
+
+								textbox = {
+									raw_text = "#bold [FixedPointToInt(Building.GetConsumption(Goods.Self))|D]#!"
+									visible = "[Not(Building.HasInputShortage(Goods.Self))]"
+									position = { 55 0 }
+									autoresize = yes
+									parentanchor = left|vcenter
+									widgetanchor = left|vcenter
+									align = left|nobaseline
+									tooltip = "TOOLTIP_BUILDING_USES_UNITS_INFO"
+								}
+
+								textbox = {
+									raw_text = "#bold #n [FixedPointToInt(Building.GetConsumption(Goods.Self))|D]#!#!"
+									visible = "[Building.HasInputShortage(Goods.Self)]"
+									position = { 55 0 }
+									autoresize = yes
+									parentanchor = left|vcenter
+									widgetanchor = left|vcenter
+									align = left|nobaseline
+									tooltip = "TOOLTIP_BUILDING_USES_UNITS_INFO"
+								}
+
+								textbox = {
+									raw_text = "#BOLD @money![FixedPointToInt(Building.GetConsumptionValue(Goods.Self))|1*]#! ([Goods.GetCompareIconAgainstBasePriceNoFormatting( Goods.GetStatePrice )])"
+									position = { -10 0 }
+									autoresize = yes
+									align = right|nobaseline
+									parentanchor = right|vcenter
+									widgetanchor = right|vcenter
+									### This tooltip blocks going to the locked tooltip of the good, therefore it is commented out
+									#tooltip = "TOOLTIP_BUILDING_USES_VALUE_INFO"
+								}
+							}
+						}
+					}
+
+					### wages
+					building_process_entry = {
+						blockoverride "visible" {
+							visible = "[GreaterThan_CFixedPoint(Building.GetLastWagesExpenses, '(CFixedPoint)0')]"
+						}
+						blockoverride "text" {
+							text = "WAGES"
+						}
+						blockoverride "text_right" {
+							raw_text = "#variable @money![Building.GetLastWagesExpenses|K]#!"
+							tooltip = "[Building.GetLastWagesExpensesDesc]"
+						}
+					}
+
+					### slave upkeep
+					building_process_entry = {
+						blockoverride "visible" {
+							visible = "[Or( Building.HasSlaves, GreaterThan_CFixedPoint(Building.GetLastSlaveUpkeep, '(CFixedPoint)0') )]"
+						}
+						blockoverride "text" {
+							text = "SLAVE_UPKEEP"
+							tooltip = "[Building.GetLastSlaveUpkeepDesc]"
+						}
+						blockoverride "text_right" {
+							raw_text = "#variable @money![Building.GetLastSlaveUpkeep|K]#!"
+							tooltip = "[Building.GetLastSlaveUpkeepDesc]"
+						}
+					}
+
+					### tariffs
+					building_process_entry = {
+						blockoverride "visible" {
+							visible = "[GreaterThan_CFixedPoint(Building.GetTariffsPaid, '(CFixedPoint)0')]"
+						}
+						blockoverride "text" {
+							text = "[concept_tariffs]"
+						}
+						blockoverride "text_right" {
+							raw_text = "#variable @money![Building.GetTariffsPaid|K]#!"
+						}
+					}
+
+					### infrastructure
+					building_process_entry = {
+						blockoverride "visible" {
+							visible = "[Building.UsesInfrastructure]"
+						}
+						blockoverride "text" {
+							tooltip = BUILDING_INFRA_USAGE_TOOLTIP
+							text = "BUILDING_INFRA_USAGE"
+						}
+					}
+				}
+
+				### center arrow
+				icon = {
+					size = { 30 30 }
+					texture = "gfx/interface/icons/generic_icons/turns_into.dds"
+					parentanchor = center
+					alpha = "[TransparentIfFalse(Building.IsActive)]"
+				}
+
+				### right
+				flowcontainer = {
+					name = "tutorial_highlight_revenues"
+					direction = vertical
+					spacing = 5
+					minimumsize = { 250 -1 }
+					parentanchor = right|vcenter
+					ignoreinvisible = yes
+					alpha = "[TransparentIfFalse(Building.IsActive)]"
+
+					### goods
+					flowcontainer = {
+						parentanchor = hcenter
+						direction = vertical
+						datamodel = "[Building.AccessProducedGoods]"
+
+						item = {
+							widget = {
+								size = { 250 50 }
+								tooltipwidget = {
+									FancyTooltip_Goods = {}
+								}
+
+								button = {
+									size = { 100% 40 }
+									parentanchor = vcenter
+									using = default_button
+									onclick = "[InformationPanelBar.OpenGoodsStatePanel(Building.GetState, Goods.Self)]"
+									onrightclick = "[RightClickMenuManager.ShowForGoods(Goods.AccessSelf)]"
+								}
+
+								icon = {
+									size = { 50 50 }
+									texture = "[Goods.GetTexture]"
+									position = { 3 0 }
+									parentanchor = left|vcenter
+								}
+
+								icon = {
+									size = { 25 25 }
+									visible = "[And(Building.HasAnyInputShortage,GreaterThan_CFixedPoint(Building.GetInputShortagePenalty, '(CFixedPoint)0'))]"
+									texture = "gfx/interface/icons/generic_icons/goods_shortage.dds"
+									tooltip = "GOODS_OUTPUT_PENALTY_TOOLTIP"
+									parentanchor = bottom
+								}
+
+								icon = {
+									size = { 25 25 }
+									visible = "[And(Not(Building.HasAnyInputShortage),GreaterThan_CFixedPoint(Building.GetInputShortagePenalty, '(CFixedPoint)0'))]"
+									texture = "gfx/interface/icons/generic_icons/goods_shortage.dds"
+									tooltip = "GOODS_OUTPUT_PENALTY_LINGERING_TOOLTIP"
+									parentanchor = bottom
+								}
+
+								textbox = {
+									raw_text = "#bold [FixedPointToInt(Building.GetProduction(Goods.Self))|D]#!"
+									visible = "[Not(GreaterThan_CFixedPoint(Building.GetInputShortagePenalty, '(CFixedPoint)0'))]"
+									position = { 55 0 }
+									parentanchor = left|vcenter
+									autoresize = yes
+									align = left|nobaseline
+									tooltip = "TOOLTIP_BUILDING_PRODUCES_UNITS_INFO"
+								}
+
+								textbox = {
+									raw_text = "#bold #n [FixedPointToInt(Building.GetProduction(Goods.Self))|D]#!#!"
+									visible = "[GreaterThan_CFixedPoint(Building.GetInputShortagePenalty, '(CFixedPoint)0')]"
+									position = { 55 0 }
+									parentanchor = left|vcenter
+									autoresize = yes
+									align = left|nobaseline
+									tooltip = "TOOLTIP_BUILDING_PRODUCES_UNITS_INFO"
+								}
+
+								textbox = {
+									raw_text = "#BOLD @money![FixedPointToInt(Building.GetProductionValue(Goods.Self))|*1]#! ([Goods.GetCompareIconAgainstBasePriceNoFormatting( Goods.GetStatePrice ) ])"
+									position = { -10 0 }
+									autoresize = yes
+									align = right|nobaseline
+									parentanchor = right|vcenter
+									### This tooltip blocks going to the locked tooltip of the good, therefore it is commented out
+									#tooltip = "TOOLTIP_BUILDING_PRODUCES_VALUE_INFO"
+								}
+							}
+						}
+					}
+
+					### military production
+					building_process_entry = {
+						blockoverride "visible" {
+							visible = "[Building.IsMilitaryBuilding]"
+						}
+						blockoverride "text" {
+							text = "[Building.GetCombatUnitProduction]"
+							tooltip = "MILITARY_UNITS_PRODUCTION"
+						}
+					}
+
+					### modifiers
+					flowcontainer = {
+						parentanchor = hcenter
+						direction = vertical
+						spacing = 5
+						datamodel = "[Building.GetProducedModifiers.GetEntries]"
+						visible = "[Not(IsDataModelEmpty(Building.GetProducedModifiers.GetEntries))]"
+						item = {
+							flowcontainer = {
+								spacing = 5
+								maximumsize = { 250 -1 }
+								minimumsize = { 250 -1 }
+								margin = { 10 8 }
+								
+								icon = {
+									size = { 25 25 }
+									visible = "[And(Building.CanBeAffectedByInputShortage(ModifierEntry.Self),And(Building.HasAnyInputShortage,GreaterThan_CFixedPoint(Building.GetInputShortagePenalty, '(CFixedPoint)0')))]"
+									texture = "gfx/interface/icons/generic_icons/goods_shortage.dds"
+									tooltip = "GOODS_OUTPUT_PENALTY_TOOLTIP"
+									parentanchor = vcenter
+								}
+
+								icon = {
+									size = { 25 25 }
+									visible = "[And(Building.CanBeAffectedByInputShortage(ModifierEntry.Self),And(Not(Building.HasAnyInputShortage),GreaterThan_CFixedPoint(Building.GetInputShortagePenalty, '(CFixedPoint)0')))]"
+									texture = "gfx/interface/icons/generic_icons/goods_shortage.dds"
+									tooltip = "GOODS_OUTPUT_PENALTY_LINGERING_TOOLTIP"
+									parentanchor = vcenter
+								}
+
+								background = {
+									using = entry_bg_simple
+								}
+
+								textbox = {
+									text = "[ModifierEntry.GetFormattedValue] [ModifierEntry.GetName]"
+									tooltip = "BUILDING_DETAILS_PRODUCED_MODIFIER_TOOLTIP"
+									autoresize = yes
+									multiline = yes
+									align = left|nobaseline
+									parentanchor = vcenter
+									maximumsize = { 220 -1 }
+								}
+							}
+						}
+					}
+
+					### trade revenue
+					building_process_entry = {
+						blockoverride "visible" {
+							visible = "[Building.HasTradeRouteRevenue]"
+						}
+						blockoverride "text" {
+							text = "[concept_trade_revenue]"
+						}
+						blockoverride "text_right" {
+							raw_text = "#variable @money![Building.GetTradeRouteRevenue|K]#!"
+						}
+					}
+
+					building_process_entry = {
+						blockoverride "visible" {
+							visible = "[Building.ProvidesUrbanization]"
+						}
+						blockoverride "text" {
+							tooltip = BUILDING_URBANIZATION_TOOLTIP
+							raw_text = "#variable [Building.CalcUrbanizationProvided|+=]#! [concept_urbanization]"
+						}
+					}
+				}
+			}
+		}
+
+		widget = { size = { 10 20 }}
+
+		divider_clean = {}
+
+		widget = {
+			size = { @panel_width 45 }
+			parentanchor = hcenter
+			visible = "[Or(Not( StringIsEmpty( Building.GetInputMultDesc )), Not(And( StringIsEmpty(Building.GetThroughputDesc), EqualTo_CFixedPoint(Building.GetThroughputBonusCurrent, Building.GetThroughputBonusTarget) )))]"
+
+			### consumption factor
+			textbox = {
+				margin_left = 10
+				visible = "[Not( StringIsEmpty( Building.GetInputMultDesc ))]"
+				text = "INPUT_MULT"
+				tooltip = "INPUT_MULT_TOOLTIP"
+				autoresize = yes
+				default_format = "#title"
+				using = fontsize_large
+				parentanchor = left|vcenter
+				align = left|nobaseline
+			}
+
+			### throughput
+			textbox = {
+				margin_right = 10
+				visible = "[Not(And( StringIsEmpty(Building.GetThroughputDesc), EqualTo_CFixedPoint(Building.GetThroughputBonusCurrent, Building.GetThroughputBonusTarget) ))]"
+				text = "THROUGHPUT"
+				tooltip = "THROUGHPUT_TOOLTIP"
+				autoresize = yes
+				default_format = "#title"
+				using = fontsize_large
+				parentanchor = right|vcenter
+				align = right|nobaseline
+			}
+		}
+
+		### VACANCIES
+		default_header_2texts = {
+			blockoverride "text1" {
+				text = "VACANCIES"
+			}
+		}
+		empty_state = {
+			blockoverride "visible" {
+				visible = "[And(Not(NotEqualTo_int32( Building.GetNoOfEmployed, Building.GetEmployeeCap )), Building.IsActive)]"
+			}
+			blockoverride "text" {
+				text = "NO_VACANCIES"
+			}
+		}
+
+		flowcontainer = {
+			datacontext = "[Building.AccessPopsList]"
+			datacontext = "[Building]"
+			datamodel = "[PopList.AccessPopList]"
+			direction = vertical
+			using = default_list_position
+			spacing = 10
+			margin_bottom = 20
+			margin_top = 10
+			visible = "[And(Building.IsActive, Not(IsDataModelEmpty(PopList.AccessPopList)))]"
+
+			item = {
+				flowcontainer = {
+					tooltip = "[PopListItem.GetPopTypeEmploymentDesc]"
+					spacing = 10
+					visible = "[NotEqualTo_int32( PopListItem.GetMaxPopSize, PopListItem.GetWorkingAdultsPopSize )]"
+
+					default_progressbar_horizontal = {
+						size = { @panel_width_minus_10 40 }
+						visible = "[GreaterThan_int32(PopListItem.GetMaxPopSize,'(int32)0')]"
+						blockoverride "values" {
+							min = 0
+							max = "[IntToFloat(PopListItem.GetMaxPopSize)]"
+							value = "[IntToFloat(PopListItem.GetWorkingAdultsPopSize)]"
+						}
+						parentanchor = vcenter
+
+						flowcontainer = {
+							icon = {
+								size = { 40 40 }
+								texture = "[PopListItem.GetPopType.GetTexture]"
+								parentanchor = vcenter
+								tooltipwidget = {
+									FancyTooltip_PopType = {
+										datacontext = "[PopListItem.GetPopType]"
+									}
+								}
+							}
+							textbox = {
+								raw_text = "#bold [PopListItem.GetWorkingAdultsPopSize|K]#! / #maximum [PopListItem.GetMaxPopSize|K]#!"
+								autoresize = yes
+								align = left|nobaseline
+								parentanchor = vcenter
+								margin_left = 10
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	type building_process_entry = widget {
+		parentanchor = hcenter
+		block "visible" {}
+
+		background = {
+			using = entry_bg_simple
+		}
+
+		textbox = {
+			block "text" {
+				raw_text = "INSERT_TEXT"
+			}
+			autoresize = yes
+			multiline = yes
+			resizeparent = yes
+			maximumsize = { 250 -1 }
+			minimumsize = { 250 -1 }
+			align = left|nobaseline
+			margin = { 10 8 }
+		}
+
+		textbox = {
+			block "text_right" {}
+			autoresize = yes
+			multiline = yes
+			maximumsize = { 250 -1 }
+			minimumsize = { 250 -1 }
+			align = right|nobaseline
+			margin = { 10 8 }
+		}
+	}
+}

--- a/DeadMoney/gui/production_methods.gui
+++ b/DeadMoney/gui/production_methods.gui
@@ -1,0 +1,1071 @@
+# COPY-PASTED FOR NOW
+@panel_width_minus_10 = 530			# used to be 450
+@panel_width = 540  				# used to be 460
+@panel_width_half = 270				# used to be 230
+@panel_width_plus_10 = 550  		# used to be 470
+@panel_width_plus_14 = 554			# used to be 474
+@panel_width_plus_14_half = 277		# used to be 237
+@panel_width_plus_20 = 560			# used to be 480
+@panel_width_plus_30 = 570			# used to be 490
+@panel_width_plus_70 = 610			# used to be 530
+
+types production_methods
+{
+	type production_methods_entries_container = flowcontainer {
+		direction = vertical
+		parentanchor = hcenter
+		using = default_content_fade
+		spacing = 10
+
+		flowcontainer = {
+			block "production_entries" {
+			}
+			direction = vertical
+			parentanchor = hcenter
+			spacing = 5
+
+			item = {
+				buildings_production_method_item = {}
+			}
+		}
+
+		block "potential_entries_header" {
+			default_header = {
+				parentanchor = hcenter
+			}
+		}
+
+		block "potential_entries_entire_widget" {
+			flowcontainer = {
+				margin = { 7 -5 }
+				
+				dynamicgridbox = {
+					block "potential_entries" {
+					}
+					flipdirection = yes
+					datamodel_wrap = 5
+
+					item = {
+						container = {
+							producing_building_button = {}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	type production_methods_panel = default_block_window {
+		name = "production_methods_panel"
+		
+		blockoverride "animation_state_block" {
+			state = {
+				name = _show
+				start_sound = {
+					soundeffect = "event:/SFX/UI/SideBar/buildings"
+				}
+			}
+
+			state = {
+				name = _hide
+				start_sound = {
+					soundeffect = "event:/SFX/UI/SideBar/buildings_stop"
+				}
+			}
+		}		
+		
+		blockoverride "window_header_name" {
+			text = "PRODUCTION_METHODS_HEADER"
+		}
+
+
+		blockoverride "fixed_top" {
+
+			top_illu = {
+				datacontext = "[AccessPlayer]"
+				
+				blockoverride "illu" {
+					texture = "gfx/interface/illustrations/top_illus/top_illu_market.dds"
+				}
+				
+				flowcontainer = {
+					direction = vertical
+					parentanchor = center
+					spacing = 5
+					
+					flowcontainer = {
+						parentanchor = hcenter
+						spacing = 10
+						tooltip = "CONSTRUCTION_SPEED_BASE_TOOLTIP"
+
+						icon = {
+							parentanchor = vcenter
+							size = { 35 35 }
+							texture = "gfx/interface/icons/state_status_icons/has_construction.dds"
+							visible = "[Not(Country.IsConstructionPaused)]"
+						}
+
+						icon = {
+							parentanchor = vcenter
+							size = { 35 35 }
+							texture = "gfx/interface/icons/state_status_icons/has_construction_paused.dds"
+							visible = "[Country.IsConstructionPaused]"
+						}
+
+						textbox = {
+							parentanchor = vcenter
+							using = fontsize_mega
+							text = "CONSTRUCTION_VALUE"
+							autoresize = yes
+							align = center|nobaseline
+						}
+					}					
+					textbox = {
+						parentanchor = hcenter
+						using = fontsize_large
+						autoresize = yes
+						text = "CURRENT_INVESTMENT_POOL"
+						using = investment_pool_tooltip_with_graph
+						align = center|nobaseline
+					}
+				}
+			}
+
+			tab_buttons = {
+				blockoverride "first_button" {
+					text = "URBAN_BUILDINGS"
+				}
+				blockoverride "first_button_tooltip" {
+					tooltip = "URBAN_BUILDINGS"
+				}
+				blockoverride "first_button_click" {
+					onclick = "[InformationPanel.SelectTab('urban')]"
+				}
+				blockoverride "first_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('urban')]"
+				}
+				blockoverride "first_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('urban') )]"
+				}
+				blockoverride "first_button_selected" {
+					text = "URBAN_BUILDINGS"
+				}
+
+				blockoverride "second_button" {
+					text = "RURAL_BUILDINGS"
+				}
+				blockoverride "second_button_tooltip" {
+					tooltip = "RURAL_BUILDINGS"
+				}
+				blockoverride "second_button_click" {
+					onclick = "[InformationPanel.SelectTab('rural')]"
+				}
+				blockoverride "second_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('rural')]"
+				}
+				blockoverride "second_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('rural') )]"
+				}
+				blockoverride "second_button_selected" {
+					text = "RURAL_BUILDINGS"
+				}
+				blockoverride "second_button_name" {
+					name = "tutorial_highlight_rural_tab"
+				}
+
+				blockoverride "third_button" {
+					text = "DEVELOPMENT_BUILDINGS"
+				}
+				blockoverride "third_button_tooltip" {
+					tooltip = "DEVELOPMENT_BUILDINGS"
+				}
+				blockoverride "third_button_click" {
+					onclick = "[InformationPanel.SelectTab('development')]"
+				}
+				blockoverride "third_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('development')]"
+				}
+				blockoverride "third_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('development') )]"
+				}
+				blockoverride "third_button_selected" {
+					text = "DEVELOPMENT_BUILDINGS"
+				}
+				blockoverride "third_button_name" {
+					name = "tutorial_highlight_development_tab"
+				}
+
+				blockoverride "fourth_button" {
+					text = "CONSTRUCTION"
+				}
+				blockoverride "fourth_button_tooltip" {
+					tooltip = "CONSTRUCTION"
+				}
+				blockoverride "fourth_button_click" {
+					onclick = "[InformationPanel.SelectTab('construction_queues')]"
+				}
+				blockoverride "fourth_button_visibility" {
+					visible = "[InformationPanel.IsTabSelected('construction_queues')]"
+				}
+				blockoverride "fourth_button_visibility_checked" {
+					visible = "[Not( InformationPanel.IsTabSelected('construction_queues') )]"
+				}
+				blockoverride "fourth_button_selected" {
+					text = "CONSTRUCTION"
+				}
+			}
+		}
+		
+		blockoverride "scrollarea_content" {
+			
+			flowcontainer = {
+				direction = vertical
+
+				flowcontainer = {
+					using = default_list_position
+					direction = vertical
+					spacing = 5
+					margin_top = 10
+
+					production_methods_entries_container = {
+						visible = "[InformationPanel.IsTabSelected('urban')]"
+						blockoverride "production_entries" {
+							datamodel = "[ProductionMethodsPanel.AccessProductionMethodPanelEntriesUrban]"
+						}
+						blockoverride "potential_entries" {
+							datamodel = "[ProductionMethodsPanel.AccessPotentialBuildingEntriesUrban]"
+						}
+						blockoverride "text" {
+							text = "AVAILABLE_URBAN_BUILDINGS"
+						}
+					}
+
+					production_methods_entries_container = {
+						visible = "[InformationPanel.IsTabSelected('rural')]"
+						blockoverride "production_entries" {
+							datamodel = "[ProductionMethodsPanel.AccessProductionMethodPanelEntriesRural]"
+						}
+						blockoverride "potential_entries" {
+							datamodel = "[ProductionMethodsPanel.AccessPotentialBuildingEntriesRural]"
+						}
+						blockoverride "text" {
+							text = "AVAILABLE_RURAL_BUILDINGS"
+						}
+					}
+
+					production_methods_entries_container = {
+						visible = "[InformationPanel.IsTabSelected('development')]"
+						blockoverride "production_entries" {
+						datamodel = "[ProductionMethodsPanel.AccessProductionMethodPanelEntriesDevelopment]"
+						}
+						blockoverride "potential_entries" {
+						datamodel = "[ProductionMethodsPanel.AccessPotentialBuildingEntriesDevelopment]"
+						}
+						blockoverride "text" {
+							text = "AVAILABLE_DEVELOPMENT_BUILDINGS"
+						}
+					}
+
+					production_methods_entries_container = {
+						visible = "[InformationPanel.IsTabSelected('construction_queues')]"
+						datacontext = "[AccessPlayer]"
+
+						blockoverride "production_entries" {
+							datamodel = "[ProductionMethodsPanel.AccessProductionMethodPanelEntriesConstruction]"
+						}						
+
+						# There are no potential entries yet, for now hide the header and list
+						blockoverride "potential_entries_header" {}
+						blockoverride "potential_entries_entire_widget" {}
+
+						construction_queue = {}					
+					}
+				}
+			}
+		}
+
+		blockoverride "fixed_bottom" {
+			flowcontainer = {
+				visible = "[InformationPanel.IsTabSelected('construction_queues')]"
+				margin_top = 5
+				flowcontainer = {
+					visible = "[And(ProductionMethodsPanel.IsShowingGovernmentConstructions,GreaterThan_int32(ProductionMethodsPanel.GetNumGovernmentConstructionQueuePages(GetMetaPlayer.GetPlayedOrObservedCountry), '(int32)1'))]"
+					spacing = 20
+
+					button_select_arrow = {
+						size = { 25 25 }
+						mirror = horizontal
+						parentanchor = vcenter
+						using = decrease_button_sound
+						using = tooltip_above
+
+						block "tooltip_left_arrow" {
+							tooltip = "PREVIOUS_PAGE"
+						}
+
+						block "onclick_prev"
+						{
+							onclick = "[ProductionMethodsPanel.PrevGovernmentConstructionQueuePage(GetMetaPlayer.GetPlayedOrObservedCountry)]"
+						}
+					}
+
+					text_single = {
+						text = "CONSTRUCTION_CURRENT_PAGE"
+						parentanchor = vcenter
+						align = nobaseline
+					}
+
+					button_select_arrow = {
+						size = { 25 25 }
+						parentanchor = vcenter
+						using = increase_button_sound
+						using = tooltip_above
+
+						block "tooltip_right_arrow" {
+							tooltip = "NEXT_PAGE"
+						}
+
+						block "onclick_next"
+						{
+							onclick = "[ProductionMethodsPanel.NextGovernmentConstructionQueuePage(GetMetaPlayer.GetPlayedOrObservedCountry)]"
+						}
+					}
+				}
+				
+				flowcontainer = {
+					visible = "[And(ProductionMethodsPanel.IsShowingPrivateConstructions,GreaterThan_int32(ProductionMethodsPanel.GetNumPrivateConstructionQueuePages(GetMetaPlayer.GetPlayedOrObservedCountry), '(int32)1'))]"
+					spacing = 20
+
+					button_select_arrow = {
+						size = { 25 25 }
+						mirror = horizontal
+						parentanchor = vcenter
+						using = decrease_button_sound
+						using = tooltip_above
+
+						block "tooltip_left_arrow" {
+							tooltip = "PREVIOUS_PAGE"
+						}
+
+						block "onclick_prev"
+						{
+							onclick = "[ProductionMethodsPanel.PrevPrivateConstructionQueuePage(GetMetaPlayer.GetPlayedOrObservedCountry)]"
+						}
+					}
+
+					text_single = {
+						text = "CONSTRUCTION_CURRENT_PAGE_PRIVATE"
+						parentanchor = vcenter
+						align = nobaseline
+					}
+
+					button_select_arrow = {
+						size = { 25 25 }
+						parentanchor = vcenter
+						using = increase_button_sound
+						using = tooltip_above
+
+						block "tooltip_right_arrow" {
+							tooltip = "NEXT_PAGE"
+						}
+
+						block "onclick_next"
+						{
+							onclick = "[ProductionMethodsPanel.NextPrivateConstructionQueuePage(GetMetaPlayer.GetPlayedOrObservedCountry)]"
+						}
+					}
+				}
+			}
+		}
+	}
+
+	### autoexpand
+	type building_auto_expand = widget {
+		visible = "[IsPotential( Building.ToggleAutoExpand )]"
+		size = { 35 35 }
+		
+		icon = {
+			using = rotate_glow_blue
+			size = { 130% 130% }
+			visible = "[Building.IsAutoExpanding]"
+			alwaystransparent = yes
+			parentanchor = center
+			using = default_fade_in_out
+		}
+		
+		button_icon_round_action = {
+			size = { 100% 100% }
+			visible = "[Building.IsAutoExpanding]"
+			enabled = "[IsValid( Building.ToggleAutoExpand )]"
+			onclick = "[Execute( Building.ToggleAutoExpand )]" 
+			tooltip = [Building.GetAutoExpandTooltip]
+			
+			blockoverride "icon" {
+				texture = "gfx/interface/production_methods/auto_expand.dds"
+			}
+			blockoverride "icon_size" {
+							size = { 77% 77% }
+			}	
+		}
+
+		button_icon_round_action = {
+			size = { 100% 100% }
+			visible = "[Not(Building.IsAutoExpanding)]"
+			enabled = "[IsValid( Building.ToggleAutoExpand )]"
+			onclick = "[Execute( Building.ToggleAutoExpand )]" 
+			tooltip = [Building.GetAutoExpandTooltip]
+			using = confirm_button_sound
+			
+			blockoverride "icon" {
+				texture = "gfx/interface/production_methods/auto_expand_not.dds"
+			}
+			blockoverride "icon_size" {
+							size = { 77% 77% }
+			}
+		}
+	}
+	
+#	### has new PM icon_ANIMATED_ARROW_
+#	type has_new_pm_icon = icon {
+#		size = { 26 26 }
+#		framesize = { 52 52 }
+#		texture = "gfx/interface/production_methods/has_new_pm_icon.dds"
+#		block "visible" {}
+#		tooltip = "TOOLTIP_NEW_PRODUCTION_METHOD"
+#		
+#		state = {
+#			trigger_on_create = yes
+#			name = 1
+#			frame = 1
+#			next = 2
+#			duration = 0.10
+#		}
+#		state = {
+#			name = 2
+#			frame = 2
+#			next = 3
+#			duration = 0.11
+#		}
+#		state = {
+#			name = 3
+#			frame = 3
+#			next = 4
+#			duration = 0.12
+#		}
+#		state = {
+#			name = 4
+#			frame = 4
+#			next = 5
+#			duration = 0.13
+#		}
+#		state = {
+#			name = 5
+#			frame = 5
+#			next = 6
+#			duration = 0.14
+#		}
+#		state = {
+#			name = 6
+#			frame = 5
+#			duration = 1.5
+#		}
+#	}
+	
+	### has new PM icon_Exclamation mark_
+	type has_new_pm_icon = icon {
+		size = { 16 16 }
+		framesize = { 52 52 }
+		texture = "gfx/interface/current_situations/icon_situation_unread.dds"
+		block "visible" {}
+		tooltip = "TOOLTIP_NEW_PRODUCTION_METHOD"
+	}
+
+	### PM ITEM
+	type buildings_production_method_item = flowcontainer {
+		block "visible" {
+			visible = "[Not(IsDataModelEmpty(ProductionMethodsPanelEntry.AccessBuildings))]"
+		}
+
+		block "datacontext" {
+			datacontext = "[ProductionMethodsPanelEntry.GetBuildingType]"
+		}
+
+		direction = vertical
+		spacing = 10
+
+		### TOP ITEM
+		widget = {
+			size = { @panel_width_plus_14 95 }
+
+			highlight_tutorial_ui = {
+	   			visible = "[BuildingType.IsBeingTutorialHighlighted]"
+	    	}
+
+			### DROPDOWN / EXPAND
+			section_header_button = {
+				parentanchor = left
+				position = { 110 0 }
+				size = { 440 38 }
+				
+				blockoverride "left_text" {
+					raw_text = "#v [BuildingType.GetNameNoFormatting]#!"
+				}
+				blockoverride "right_text" {
+					section_header_right_text = {
+						visible = "[And( And(Not(BuildingType.IsGovernmentFunded), Not(BuildingType.IsSubsistenceBuilding)), GreaterThan_int32( BuildingType.GetLevelCountInCountry(GetPlayer.Self), '(int32)0' ))]"
+						text = "[BuildingType.GetProductivitySpanDesc(GetPlayer.Self)]"
+						tooltip = "PRODUCTIVITY_SPAN_TOOLTIP"
+					}
+				}
+				
+				blockoverride "onclick" {
+					onclick = "[ProductionMethodsPanelEntry.ToggleExpand]"
+				}
+				
+				blockoverride "onclick_showmore" {
+					visible = "[Not(ProductionMethodsPanelEntry.IsExpanded)]"
+				}
+
+				blockoverride "onclick_showless" {
+					visible = "[ProductionMethodsPanelEntry.IsExpanded]"
+				}
+			}
+			
+			### production methods grouped
+			container = {
+				position = { 112 0 }
+				parentanchor = bottom
+				name = "tutorial_highlight_production_methods"
+				
+				fixedgridbox = {
+					datamodel = "[ProductionMethodsPanelEntry.AccessBuildingType.AccessProductionMethodGroups]"
+					flipdirection = yes
+					addcolumn = 51
+					addrow = 50
+
+					item = {
+						widget = {
+							size = { 49 50 }
+							tooltip = "[ProductionMethodsPanelEntry.GetBulkChangeTooltip( ProductionMethodGroup.Self )]"
+							using = tooltip_above
+
+							button = {
+								visible = "[NotEqualTo_int32( GetDataModelSize( ProductionMethodGroup.AccessCountryProductionMethods( GetPlayer.Self ) ), '(int32)1' )]"
+								distribute_visual_state = no
+								inherit_visual_state = no
+								using = expand_button_bg_no_fade
+								size = { 100% 100% }
+								onclick = "[RightClickMenuManager.ToggleSwitchProductionMethodMenuForType(ProductionMethodsPanelEntry.AccessBuildingType, ProductionMethodGroup.AccessSelf, PdxGuiWidget.AccessSelf)]"
+							}
+							
+							### pm icon
+							icon = {
+								visible = "[ProductionMethodsPanelEntry.HasAllSameProductionMethod( ProductionMethodGroup.Self )]"
+								size = { 39 40 }
+								parentanchor = center
+								texture = "[ProductionMethodsPanelEntry.GetAllSameProductionMethodTexture( ProductionMethodGroup.Self )]"
+							}
+							
+							### mixed pm icon
+							icon = {
+								visible = "[Not( ProductionMethodsPanelEntry.HasAllSameProductionMethod( ProductionMethodGroup.Self ) )]"
+								size = { 35 35 }
+								parentanchor = center
+								texture = "[ProductionMethodGroup.GetMixedIcon]"
+							}
+							
+							### new pm
+							has_new_pm_icon = {
+								position = { -2 2 }
+								parentanchor = bottom|left
+								blockoverride "visible" {
+									visible = "[GetPlayer.HasNewProductionMethodInGroup( ProductionMethodGroup.Self )]"
+								}
+							}
+																
+
+							### nr available
+							textbox = {
+								raw_text = "#bold [ProductionMethodGroup.GetNumAvailableOptionsForBuildingType(ProductionMethodsPanelEntry.AccessBuildingType)]#!"
+								parentanchor = top|right
+								position = { -5 0 }
+								autoresize = yes
+								align = right|nobaseline
+								visible = "[GreaterThan_int32( ProductionMethodGroup.GetNumAvailableOptionsForBuildingType(ProductionMethodsPanelEntry.AccessBuildingType), '(int32)1')]"
+								tooltip = "PRODUCTION_METHOD_OPTIONS_BULK"
+								using = tooltip_above
+								using = fontsize_small
+
+								background = {
+									using = default_background
+									margin = { 8 4 }
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			### building icon
+			button = {
+				texture = "[BuildingType.GetTexture]"
+				onrightclick = "[RightClickMenuManager.ShowForBuildingType(BuildingType.AccessSelf)]"
+				effectname = "NoHighlight"
+				distribute_visual_state = no
+				inherit_visual_state = no
+
+				size = { 100 100 }
+				position = { 7 0 }
+				parentanchor = left|vcenter
+
+				tooltipwidget = {
+					FancyTooltip_BuildingType = {}
+				}
+			}
+			
+			### ACTION BUTTONS
+			flowcontainer = {
+				parentanchor = bottom|right
+				position = { -8 -5 }
+				spacing = 4
+				
+				### expand
+				button_icon_round_map_interaction = {
+					size = { 40 40 }
+					blockoverride "icon" {
+						texture = "gfx/interface/buttons/button_icons/plus.dds"
+					}
+					
+					onclick = "[BuildingType.ActivateExpansionLens]"
+					using = select_button_sound
+					visible = "[Or( BuildingType.IsBuildable, BuildingType.IsExpandable )]"
+					tooltip = "EXPAND"
+				}
+
+				### subsidize
+				widget = {
+					size = { 40 40 }
+					visible = "[BuildingType.CanBeSubsidized]"
+					
+					icon = {
+						using = rotate_glow_blue
+						size = { 130% 130% }
+						visible = "[ProductionMethodsPanelEntry.HasAllSubsidies]"
+						alwaystransparent = yes
+						parentanchor = center
+						using = default_fade_in_out
+					}
+					
+					button_icon_round_action = {
+						size = { 100% 100% }
+						visible = "[ProductionMethodsPanelEntry.HasAllSubsidies]"
+						enabled = "[IsValid( ProductionMethodsPanelEntry.ToggleAllSubsidies )]"
+						onclick = "[Execute( ProductionMethodsPanelEntry.ToggleAllSubsidies )]"					
+						tooltip = "SUBSIDIZED_ALL_YES"
+						
+						blockoverride "icon" {
+							texture = "gfx/interface/production_methods/subsidized.dds"
+						}
+						blockoverride "icon_size" {
+							size = { 70% 70% }
+						}
+					}
+					button_icon_round_action = {
+						size = { 100% 100% }
+						visible = "[ProductionMethodsPanelEntry.HasAllNoSubsidies]"
+						enabled = "[IsValid( ProductionMethodsPanelEntry.ToggleAllSubsidies )]"
+						onclick = "[Execute( ProductionMethodsPanelEntry.ToggleAllSubsidies )]"
+						tooltip = "SUBSIDIZED_ALL_NO"
+						using = confirm_button_sound
+						
+						blockoverride "icon" {
+							texture = "gfx/interface/production_methods/subsidized_not.dds"
+						}
+						blockoverride "icon_size" {
+							size = { 70% 70% }
+						}
+					}
+					button_icon_round_action = {
+						size = { 100% 100% }
+						visible = "[ProductionMethodsPanelEntry.HasMixedSubsidies]"
+						enabled = "[IsValid( ProductionMethodsPanelEntry.ToggleAllSubsidies )]"
+						onclick = "[Execute( ProductionMethodsPanelEntry.ToggleAllSubsidies )]"
+						tooltip = "SUBSIDIZED_ALL_MIXED"
+						
+						blockoverride "icon" {
+							texture = "gfx/interface/production_methods/subsidized_mixed.dds"
+						}
+						blockoverride "icon_size" {
+							size = { 70% 70% }
+						}
+					}
+				}
+
+				### auto expand
+				widget = {
+					size = { 40 40 }
+					visible = "[BuildingType.CanBeAutoExpanded]"
+					
+					icon = {
+						using = rotate_glow_blue
+						size = { 130% 130% }
+						visible = "[And(ProductionMethodsPanelEntry.HasAllAutoExpand, ProductionMethodsPanelEntry.GetBuildingType.CanBeAutoExpanded)]"
+						alwaystransparent = yes
+						parentanchor = center
+						using = default_fade_in_out
+					}
+					
+					button_icon_round_action = {
+						size = { 100% 100% }
+						visible = "[And(ProductionMethodsPanelEntry.HasAllAutoExpand, ProductionMethodsPanelEntry.GetBuildingType.CanBeAutoExpanded)]"
+						enabled = "[IsValid( ProductionMethodsPanelEntry.ToggleAllAutoExpand )]"
+						onclick = "[Execute( ProductionMethodsPanelEntry.ToggleAllAutoExpand )]"					
+						tooltip = "AUTO_EXPAND_ALL_YES"
+						
+						blockoverride "icon" {
+							texture = "gfx/interface/production_methods/auto_expand.dds"
+						}
+						blockoverride "icon_size" {
+							size = { 70% 70% }
+						}
+					}
+					button_icon_round_action = {
+						size = { 100% 100% }
+						visible = "[And(ProductionMethodsPanelEntry.HasAllNoAutoExpand, ProductionMethodsPanelEntry.GetBuildingType.CanBeAutoExpanded)]"
+						enabled = "[IsValid( ProductionMethodsPanelEntry.ToggleAllAutoExpand )]"
+						onclick = "[Execute( ProductionMethodsPanelEntry.ToggleAllAutoExpand )]"
+						tooltip = "AUTO_EXPAND_ALL_NO"
+						using = confirm_button_sound
+						
+						blockoverride "icon" {
+							texture = "gfx/interface/production_methods/auto_expand_not.dds"
+						}
+						blockoverride "icon_size" {
+							size = { 70% 70% }
+						}
+					}
+					button_icon_round_action = {
+						size = { 100% 100% }
+						visible = "[ProductionMethodsPanelEntry.HasMixedAutoExpand]"
+						enabled = "[IsValid( ProductionMethodsPanelEntry.ToggleAllAutoExpand )]"
+						onclick = "[Execute( ProductionMethodsPanelEntry.ToggleAllAutoExpand )]"
+						tooltip = "AUTO_EXPAND_ALL_MIXED"
+						
+						blockoverride "icon" {
+							texture = "gfx/interface/production_methods/subsidized_mixed.dds"
+						}
+						blockoverride "icon_size" {
+							size = { 70% 70% }
+						}
+					}
+				}
+				
+			}
+
+			### PRODUCTIVITY SPAN ###
+			textbox = {
+				text = "BUILDING_TYPE_COUNT"
+				autoresize = yes
+				position = { 11 -3 }
+				parentanchor = bottom
+				align = hcenter|nobaseline
+				using = fontsize_large
+				minimumsize = { 26 26 }
+			}
+		}
+
+		### EXPANDED LIST OF BUILDINGS
+		expanded_list = {
+			using = expanded_list_bg
+			datamodel = "[ProductionMethodsPanelEntry.AccessBuildings]"
+			visible = "[ProductionMethodsPanelEntry.IsExpanded]"
+
+			item = {
+				widget = {
+					highlight_tutorial_ui = {
+						visible = "[Building.IsBeingTutorialHighlighted]"
+					}
+					size = { @panel_width 105 }
+					parentanchor = hcenter
+					
+					background = {
+						using = entry_bg_simple
+					}
+					onmousehierarchyenter = "[AccessHighlightManager.HighlightBuilding(Building.Self)]"
+					onmousehierarchyleave = "[AccessHighlightManager.RemoveHighlight]"
+					alwaystransparent = no
+
+					### building button
+					button = {
+						parentanchor = hcenter
+						position = { 0 5 }
+						size = { @panel_width_minus_10 38 }
+						using = default_button
+						
+						onclick = "[InformationPanelBar.OpenBuildingDetailsPanel(Building.AccessSelf)]"
+						onrightclick = "[RightClickMenuManager.ShowForBuilding(Building.AccessSelf)]"
+						distribute_visual_state = no
+						
+						tooltipwidget = {
+							FancyTooltip_Building = {}
+						}
+						
+						textbox = {
+							position = { 15 0 }
+							raw_text = "#v [Building.GetState.GetName]#!"
+							size = { 305 30 }
+							align = left|nobaseline
+							elide = right
+							parentanchor = left|vcenter
+						}
+						
+						### PROFITABLE
+						textbox = {
+							widgetid = "[Concatenate('productivity_value', Building.GetIDString)]"
+							visible = "[And(Not(Building.IsGovernmentFunded), Not(Building.IsSubsistenceBuilding))]"
+							position = { -10 0 }
+							raw_text = "#tooltippable #tooltip:[Building.GetTooltipTag],TOOLTIP_BUILDING_PRODUCTIVITY,GraphTooltipTypeProfitability #v @money![Building.GetAverageAnnualEarningsPerEmployeeFormatted|1+]#!#!#!"
+							autoresize = yes
+							align = nobaseline
+							parentanchor = right|vcenter
+						}
+					}
+					
+					### production methods single
+					fixedgridbox = {
+						position = { 130 -5 }
+						parentanchor = bottom
+						datamodel = "[Building.AccessProductionMethodGroups]"
+						flipdirection = yes
+						addcolumn = 52
+						addrow = 50
+
+						item = {
+							widget = {
+								size = { 50 50 }
+								datacontext = "[Building.AccessProductionMethod(ProductionMethodGroup.Self)]"
+								datacontext = "[ProductionMethod]"
+                                datacontext = "[Building]"
+                                datacontext = "[ProductionMethodGroup]"
+								using = tooltip_above
+								tooltip = "CHANGE_FROM_CURRENT_PRODUCTION_METHOD_TOOLTIP"
+								
+								button = {
+									visible = "[NotEqualTo_int32( GetDataModelSize( ProductionMethodGroup.AccessBuildingProductionMethods( Building.Self ) ), '(int32)1' )]"
+									using = expand_button_bg_no_fade
+									size = { 100% 100% }
+									onclick = "[RightClickMenuManager.ToggleSwitchProductionMethodMenu(Building.AccessSelf, ProductionMethodGroup.AccessSelf, PdxGuiWidget.AccessSelf)]"
+								}
+
+								icon = {
+									size = { 40 40 }
+									parentanchor = center
+									texture = "[ProductionMethod.GetTexture]"
+								}
+								
+								### new pm
+								has_new_pm_icon = {
+									position = { -2 2 }
+									parentanchor = bottom|left
+									blockoverride "visible" {
+										visible = "[And(Building.IsOwner( GetPlayer.Self ), GetPlayer.HasNewProductionMethodInSameGroup( Building.GetBuildingType.Self, ProductionMethod.Self ))]"
+									}
+								}								
+
+								### nr available
+								textbox = {
+									raw_text = "#P #bold [ProductionMethodGroup.GetNumAvailableOptions(Building.AccessSelf)]#!#!"
+									parentanchor = top|right
+									position = { -5 0 }
+									autoresize = yes
+									align = right|nobaseline
+									visible = "[NotEqualTo_int32( ProductionMethodGroup.GetNumAvailableOptions(Building.AccessSelf), '(int32)1')]"
+									tooltip = "PRODUCTION_METHOD_OPTIONS"
+									using = tooltip_above
+									using = fontsize_small
+
+									background = {
+										using = default_background
+										margin = { 8 4 }
+									}
+								}
+							}
+						}
+					}
+
+					### ACTION BUTTONS
+					flowcontainer = {
+						parentanchor = bottom|right
+						position = { -5 -15 }
+						spacing = 5
+					
+						### subsidize
+						widget = {
+							size = { 80 35 }
+							
+							textbox = {
+								raw_text = "#N @money!#bold -[Building.GetSubsidies|D]#!"
+								tooltip = "[Building.GetSubsidiesDesc]"
+								autoresize = yes
+								position = { 0 0 }
+								align = nobaseline
+								parentanchor = right|vcenter
+								visible = "[And(Building.GetBuildingType.CanBeSubsidized,Building.IsSubsidized)]"
+								alpha = 0
+								
+								state = {
+									name = _show
+									position_x = -42
+									alpha = 1
+									duration = 0.2
+									using = Animation_Curve_Default
+								}
+								state = {
+									name = _hide
+									alpha = 0
+									duration = 0.4
+									position_x = 0
+									using = Animation_Curve_Default
+								}
+							}
+							
+							widget = {
+								size = { 35 35 }
+								parentanchor = right
+								
+								icon = {
+									using = rotate_glow_blue
+									size = { 130% 130% }
+									visible = "[And(Building.GetBuildingType.CanBeSubsidized,Building.IsSubsidized)]"
+									alwaystransparent = yes
+									parentanchor = center
+									using = default_fade_in_out
+								}
+								button_icon_round_action = {
+									size = { 100% 100% }
+									visible = "[And(Building.GetBuildingType.CanBeSubsidized,Building.IsSubsidized)]"
+									enabled = "[IsValid( Building.ToggleSubsidies )]"
+									onclick = "[Execute( Building.ToggleSubsidies )]" 
+									tooltip = SUBSIDIZED_YES
+									
+									blockoverride "icon" {
+										texture = "gfx/interface/production_methods/subsidized.dds"
+									}
+									blockoverride "icon_size" {
+										size = { 80% 80% }
+									}
+								}
+								
+								button_icon_round_action = {
+									size = { 100% 100% }							
+									visible = "[And(Building.GetBuildingType.CanBeSubsidized,Not(Building.IsSubsidized))]"
+									enabled = "[IsValid( Building.ToggleSubsidies )]"
+									onclick = "[Execute( Building.ToggleSubsidies )]" 
+									tooltip = SUBSIDIZED_NO
+									using = confirm_button_sound
+									
+									blockoverride "icon" {
+										texture = "gfx/interface/production_methods/subsidized_not.dds"
+									}
+									blockoverride "icon_size" {
+										size = { 80% 80% }
+									}
+								}
+							}
+						}
+						
+						### AUTOEXPAND
+						building_auto_expand = {}
+					}
+
+					flowcontainer = {
+						position = { 5 21 }
+						direction = vertical
+						spacing = 5
+						parentanchor = vcenter
+
+						### DOWNSIZE / EXPAND
+						container = {
+							minimumsize = { 110 35 }
+
+							### DOWNSIZE
+							button_icon_minus_action = {
+								size = { 35 35 }
+								parentanchor = vcenter
+								tooltip = "[Building.GetDownsizeTooltip]"
+								onclick = "[Execute( Building.Downsize )]"
+								enabled = "[IsValid( Building.Downsize )]"
+								visible = "[Not( ShouldAskConfirmation( Building.Downsize ) )]"
+								using = tooltip_below
+							}
+
+							### DOWNSIZE WITH CONFIRMATION
+							button_icon_minus_action = {
+								size = { 35 35 }
+								parentanchor = vcenter
+								tooltip = "[Building.GetDownsizeTooltip]"
+								onclick = "[PopupManager.AskConfirmation( Building.Downsize )]"
+								enabled = "[IsValid( Building.Downsize )]"
+								visible = "[ShouldAskConfirmation( Building.Downsize )]"
+								using = tooltip_below
+							}
+
+							### CANCEL CONSTRUCTION
+							button_icon_minus_action = {
+								size = { 35 35 }
+								parentanchor = vcenter
+								tooltip = "[Building.GetCancelConstructionTooltip]"
+								visible = "[IsValid( Building.CancelConstruction )]"
+								onclick = "[Execute( Building.CancelConstruction )]"
+								using = tooltip_below
+							}
+
+							### LEVEL
+							container = {
+								position = { 35 0 }
+								background = {
+									using = entry_bg
+									margin = { 0 -2 }
+								}
+
+								textbox = {
+									text = "[Building.GetExpansionLevelDesc]"
+									align = hcenter|nobaseline
+									size = { 40 35 }
+									elide = right
+									fontsize_min = 12
+								}
+							}
+
+							### EXPAND
+							button_icon_plus_action = {
+								widgetid = "[Concatenate('building_expand', Building.GetIDString)]"
+								position = { 75 0 }
+								size = { 35 35 }
+								parentanchor = vcenter
+								tooltip = "[Building.GetQueueConstructionTooltip]"
+								onclick = "[Execute( Building.QueueConstruction )]"
+								enabled = "[IsValid( Building.QueueConstruction )]"
+								visible = "[And(Building.GetOwner.IsLocalPlayer, Building.IsExpandable)]"
+							}
+						}
+
+						### BUILD PROGRESS
+						default_progressbar_horizontal = {
+							visible = "[Building.HasConstructionQueued]"
+							tooltip = "BUILDING_PROGRESS_TOOLTIP"
+							size = { 100 5 }
+							using = default_list_position
+
+							blockoverride "values" {
+								value = "[Building.GetConstructionProgressPercentage]"
+								min = 0
+								max = 1
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Slightly squeezed and moved the PM buttons, so 6 different PMs can show up. Needed so there can be 6 PMs instead of the vanilla 5, since basically every building needs a "security" PM